### PR TITLE
Fixed a bug introduced by upgrading to Flutter 3.0.0

### DIFF
--- a/packages/learning_input_image/lib/src/input_camera.dart
+++ b/packages/learning_input_image/lib/src/input_camera.dart
@@ -62,7 +62,7 @@ class _InputCameraViewState extends State<InputCameraView> {
     super.initState();
 
     _imagePicker = ImagePicker();
-    WidgetsBinding.instance?.addPostFrameCallback((_) async {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       await _initializeCamera();
       if (_isLive) await _startLiveStream();
       _refresh();


### PR DESCRIPTION
WidgetBindings are non-nullable starting in Flutter 3.0.0